### PR TITLE
fix(server-mock): Changing port for server-mock

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,7 +24,7 @@ services:
     networks:
       - dev-network
     ports:
-      - '8080:8080'
+      - '5000:5000'
 
 networks:
   dev-network:

--- a/project-clara-server/server-mock/src/main/resources/application.properties
+++ b/project-clara-server/server-mock/src/main/resources/application.properties
@@ -1,0 +1,1 @@
+server.port = 5000


### PR DESCRIPTION
Changing port because 8080 is used by jenkins

BREAKING CHANGE: Using port 5000 instead of 8080

## PR Checklist
Does please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/project-clara/project-clara/blob/develop/.github/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #15


## What is the new behavior?
Start at port 5000

## Does this PR introduce a breaking change?
```
[X] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
Server-mock is now running on port 5000 instead of 8080

## Other information
