### PR TITLE
refactor(client-common): clean up empty services

### DIFF
--- a/project-clara-client/src/app/core/collections/sort.service.ts
+++ b/project-clara-client/src/app/core/collections/sort.service.ts
@@ -1,7 +1,0 @@
-import { Injectable } from '@angular/core';
-
-@Injectable()
-export class SortService {
-
-
-}

--- a/project-clara-client/src/app/core/core.module.ts
+++ b/project-clara-client/src/app/core/core.module.ts
@@ -3,9 +3,6 @@ import { NgModule, Optional, SkipSelf } from '@angular/core';
 import { RouterModule } from '@angular/router';
 
 import { AuthenticationModule } from './authentication/authentication.module';
-import { SortService } from './collections/sort.service';
-import { DateTimeService } from './date-time/date-time.service';
-import { FileSaverService } from './files/file-saver.service';
 import { HttpResourceModule } from './http-resource/http-resource.module';
 import { LoggingService } from './logging/logging.service';
 import { NavigationModule } from './navigation/navigation.module';
@@ -36,7 +33,7 @@ import { throwIfAlreadyLoaded } from './module-import.guard';
     NavigationModule
   ],
   declarations: [],
-  providers: [SortService, DateTimeService, FileSaverService, LoggingService]
+  providers: [ LoggingService]
 })
 export class CoreModule {
 

--- a/project-clara-client/src/app/core/date-time/date-time.service.ts
+++ b/project-clara-client/src/app/core/date-time/date-time.service.ts
@@ -1,7 +1,0 @@
-import { Injectable } from '@angular/core';
-
-@Injectable()
-export class DateTimeService {
-
-
-}

--- a/project-clara-client/src/app/core/files/file-saver.service.ts
+++ b/project-clara-client/src/app/core/files/file-saver.service.ts
@@ -1,7 +1,0 @@
-import { Injectable } from '@angular/core';
-
-@Injectable()
-export class FileSaverService {
-
-
-}


### PR DESCRIPTION
until we need SortService etc, we should delete this services

BREAKING CHANGE: SortService, DateTimeService and FileSaver will be not
longer injectable (currently they are empty)

## PR Checklist
Does please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/project-clara/project-clara/blob/develop/.github/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[X] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
Empty services introduced

## What is the new behavior?
Empty services were deleted

## Does this PR introduce a breaking change?
```
[ ] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
@gmatysik: Wäre es für dich in Ordnung die Services auch erst einmal rauszulassen?