### PR TITLE
fix(server-mock): switing to ports 9000

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,7 +24,7 @@ services:
     networks:
       - dev-network
     ports:
-      - '5000:5000'
+      - '9000:9000'
 
 networks:
   dev-network:

--- a/project-clara-server/server-mock/src/main/resources/application.properties
+++ b/project-clara-server/server-mock/src/main/resources/application.properties
@@ -1,1 +1,1 @@
-server.port = 5000
+server.port = 9000


### PR DESCRIPTION
Docker registry uses port 5000 -> Switching to 9000



## PR Checklist
Does please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/project-clara/project-clara/blob/develop/.github/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
Mock is using Port 5000 and collides with docker registry


## What is the new behavior?
Mock is using Port 9000


## Does this PR introduce a breaking change?
```
[X] Yes
[ ] No
```

BREAKING CHANGE: Using port 9000 instead of 8080/5000